### PR TITLE
Support current Google Takeout Location History format

### DIFF
--- a/Parse Google Location History.py
+++ b/Parse Google Location History.py
@@ -17,7 +17,12 @@ if os.path.isdir(path):
     json_files = []
     for root, _dirs, files in os.walk(path):
         for name in files:
-            if name.lower().endswith('.json') and name != 'Settings.json':
+            # Case-insensitive .json check; Settings.json is reported by
+            # Google's Takeout zip with a capital S, so compare the lowercased
+            # name too to stay consistent and avoid missing it on case-sensitive
+            # filesystems if the export is ever produced with a different case.
+            lower = name.lower()
+            if lower.endswith('.json') and lower != 'settings.json':
                 json_files.append(os.path.join(root, name))
     json_files.sort()
 else:
@@ -25,7 +30,7 @@ else:
 
 entries = []
 for fp in json_files:
-    with open(fp) as f:
+    with open(fp, encoding='utf-8') as f:
         # Load in Google Location History data.
         data = json.load(f)
     # Prefer the new schema; fall back to legacy for older exports.

--- a/Parse Google Location History.py
+++ b/Parse Google Location History.py
@@ -1,16 +1,59 @@
 import json
+import os
+import sys
 
-with open('Location History.json') as f:
-    # Load in Google Location History data.
-    data = json.load(f)
+# Allow passing the Location History file or folder as an argument. Default
+# to the legacy single-file layout described in the original README.
+path = sys.argv[1] if len(sys.argv) > 1 else 'Location History.json'
+
+# Google Takeout's Location History comes in two shapes:
+#   * Legacy: a single file (e.g. "Location History.json") with a top-level
+#     "locations" array of {"latitudeE7", "longitudeE7"} dicts.
+#   * Current: a folder (e.g. "Semantic Location History/2020/") of per-month
+#     JSON files with a top-level "timelineObjects" array of "placeVisit"
+#     and "activitySegment" dicts. Settings.json holds reporting metadata,
+#     not history entries, so it is skipped.
+if os.path.isdir(path):
+    json_files = []
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            if name.lower().endswith('.json') and name != 'Settings.json':
+                json_files.append(os.path.join(root, name))
+    json_files.sort()
+else:
+    json_files = [path]
+
+entries = []
+for fp in json_files:
+    with open(fp) as f:
+        # Load in Google Location History data.
+        data = json.load(f)
+    # Prefer the new schema; fall back to legacy for older exports.
+    entries.extend(data.get('timelineObjects') or data.get('locations') or [])
 
 d = []
 
 counter = 0
 
-for i in data['locations']:
-    # Loop through JSON, append useful data to list.
-    d.append((i['latitudeE7'], i['longitudeE7']))
+for i in entries:
+    # New-schema placeVisit: {"placeVisit": {"location": {"latitudeE7": ...}}}
+    if 'placeVisit' in i:
+        loc = i['placeVisit'].get('location', {})
+        if 'latitudeE7' in loc and 'longitudeE7' in loc:
+            d.append((loc['latitudeE7'], loc['longitudeE7']))
+    # New-schema activitySegment: {"activitySegment": {"startLocation": ...,
+    # "endLocation": ...}}. Emit both endpoints so the path between them is
+    # represented in the output.
+    elif 'activitySegment' in i:
+        seg = i['activitySegment']
+        for key in ('startLocation', 'endLocation'):
+            loc = seg.get(key, {})
+            if 'latitudeE7' in loc and 'longitudeE7' in loc:
+                d.append((loc['latitudeE7'], loc['longitudeE7']))
+    # Legacy entry: {"latitudeE7": ..., "longitudeE7": ...} at the top level.
+    elif 'latitudeE7' in i and 'longitudeE7' in i:
+        d.append((i['latitudeE7'], i['longitudeE7']))
+
     counter += 1
     if not counter % 10000:
         # Print update every 10k entries (useful for large data).

--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ Older tutorials concerning Google Latitude, and Google Maps' Timeline would requ
 
 ## Parse your export data
 
-1. Download `Parse Google Location History.py` and place the script in the same directory as your `Location History.json` export.
-2. Run the script from your chosen command line (`python Parse Google Location History.py`).
+1. Download `Parse Google Location History.py` and place the script in the same directory as your export.
+2. Run the script from your chosen command line, passing the path to your Location History file or folder:
+   * **Legacy export** (pre-2020, single file): `python "Parse Google Location History.py" "Location History.json"`
+   * **Current Takeout export** (2020+, folder of monthly JSONs): `python "Parse Google Location History.py" "Semantic Location History"`
+   * You can also point it at a specific year folder, e.g. `Semantic Location History/2020`, or omit the argument to default to a `Location History.json` in the current directory.
+3. A deduplicated list of unique `latitudeE7` / `longitudeE7` coordinates will be written to `output.txt`.
 
 ## Notes
 


### PR DESCRIPTION
Fixes #1.

The original `KeyError: 'locations'` was actually a format change in Google Takeout, not a filename issue. Around 2020, Google changed the Location History export:

* **Old format** (pre-2020): a single `Location History.json` file with a top-level `locations` array of `{latitudeE7, longitudeE7}` dicts.
* **New format** (2020+): a `Semantic Location History/<year>/` folder of per-month JSON files (e.g. `2020_FEBRUARY.json`) with a top-level `timelineObjects` array of `placeVisit` and `activitySegment` dicts. `Settings.json` is reporting metadata, not history, so it is skipped.

PR #2 attempted to fix this by only changing the filename reference to `Records.json` and didn't address the schema change.

## Changes

* The script now accepts a file or folder path as the first argument (defaults to `Location History.json` for backward compatibility).
* When a folder is given, JSON files are walked recursively and `Settings.json` is skipped.
* Coordinates are extracted from `placeVisit.location`, `activitySegment.startLocation`, and `activitySegment.endLocation` (all E7 integers), plus the legacy top-level `latitudeE7`/`longitudeE7` entries.
* README updated with the new usage patterns.

## Verified

Tested with synthetic data covering:

1. Legacy single file (`Location History.json`) — backward compatible.
2. New-format single file (`2020_FEBRUARY.json`) — the original repro case.
3. Directory of monthly files (the user's broader situation).
4. Deep nested Takeout layout (`Semantic Location History/<year>/<file>.json`).
